### PR TITLE
AVRO-3041 : use default converters for unions/nullable properties

### DIFF
--- a/lang/csharp/src/apache/main/AssemblyInternalsVisibleTo.cs
+++ b/lang/csharp/src/apache/main/AssemblyInternalsVisibleTo.cs
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Avro.Test, PublicKey=00240000048000009400000006020000002400005253413100040000010001001145636d1b9616" +
+        "8c2781abfd60478f45d010fe83dd0f318404cbf67252bca8cd827f24648d47ff682f35e60307c0" +
+        "5d3cd89f0b063729cf8d2ebe6510b9e7d295dec6707ec91719d859458981f7ca1cbbea79b702b2" +
+        "fb64d1dbf0881887315345b70fa50fcf91b59e6a937c8d23919d409ee2f1f234cc4c8dbf5a29d3" +
+        "d670f3c9")]

--- a/lang/csharp/src/apache/main/Reflect/ClassCache.cs
+++ b/lang/csharp/src/apache/main/Reflect/ClassCache.cs
@@ -205,13 +205,15 @@ namespace Avro.Reflect
             var avroTypes = new[]
             {
                 avroType.MakePrimitive(),
-                avroType.MakeNullable()
+                avroType.MakeNullable(),
+                avroType // in case avroType isn't primitive (eg: a string)
             };
 
             var propTypes = new[]
             {
                 propType.MakePrimitive(),
-                propType.MakeNullable()
+                propType.MakeNullable(),
+                propType // in case propType isn't primitive (eg: a string)
             };
 
             return avroTypes

--- a/lang/csharp/src/apache/main/Reflect/DotnetClass.cs
+++ b/lang/csharp/src/apache/main/Reflect/DotnetClass.cs
@@ -51,7 +51,7 @@ namespace Avro.Reflect
                     if (avroAttr != null)
                     {
                         hasAttribute = true;
-                        _propertyMap.TryAdd(f.Name, new DotnetProperty(prop, f.Schema, avroAttr.Converter, cache));
+                        _propertyMap.TryAdd(f.Name, new DotnetProperty(prop, f.Schema, NullableConverter.CreateNullableWrapper(avroAttr.Converter, prop.PropertyType), cache));
                         break;
                     }
                 }

--- a/lang/csharp/src/apache/main/Reflect/DotnetClass.cs
+++ b/lang/csharp/src/apache/main/Reflect/DotnetClass.cs
@@ -19,7 +19,6 @@
 using System;
 using System.Reflection;
 using System.Collections.Concurrent;
-using Avro;
 
 namespace Avro.Reflect
 {
@@ -28,9 +27,9 @@ namespace Avro.Reflect
     /// </summary>
     public class DotnetClass
     {
-        private ConcurrentDictionary<string, DotnetProperty> _propertyMap = new ConcurrentDictionary<string, DotnetProperty>();
+        private readonly ConcurrentDictionary<string, DotnetProperty> _propertyMap = new ConcurrentDictionary<string, DotnetProperty>();
 
-        private Type _type;
+        private readonly Type _type;
 
         /// <summary>
         /// Constructor
@@ -52,14 +51,14 @@ namespace Avro.Reflect
                     if (avroAttr != null)
                     {
                         hasAttribute = true;
-                        _propertyMap.TryAdd(f.Name, new DotnetProperty(prop, f.Schema.Tag, avroAttr.Converter, cache));
+                        _propertyMap.TryAdd(f.Name, new DotnetProperty(prop, f.Schema, avroAttr.Converter, cache));
                         break;
                     }
                 }
 
                 if (!hasAttribute)
                 {
-                    _propertyMap.TryAdd(f.Name, new DotnetProperty(prop, f.Schema.Tag, cache));
+                    _propertyMap.TryAdd(f.Name, new DotnetProperty(prop, f.Schema, cache));
                 }
             }
         }

--- a/lang/csharp/src/apache/main/Reflect/DotnetProperty.cs
+++ b/lang/csharp/src/apache/main/Reflect/DotnetProperty.cs
@@ -24,7 +24,7 @@ namespace Avro.Reflect
 {
     internal class DotnetProperty
     {
-        private PropertyInfo _property;
+        private readonly PropertyInfo _property;
 
         public IAvroFieldConverter Converter { get; set; }
 
@@ -79,29 +79,19 @@ namespace Avro.Reflect
             return false;
         }
 
-        public DotnetProperty(PropertyInfo property, Avro.Schema.Type schemaTag,  IAvroFieldConverter converter, ClassCache cache)
+        public DotnetProperty(PropertyInfo property, Avro.Schema schema,  IAvroFieldConverter converter, ClassCache cache)
         {
             _property = property;
-            Converter = converter;
+            Converter = converter ?? cache.GetDefaultConverter(schema, _property.PropertyType);
 
-            if (!IsPropertyCompatible(schemaTag))
+            if (!IsPropertyCompatible(schema.Tag))
             {
-                if (Converter == null)
-                {
-                    var c = cache.GetDefaultConverter(schemaTag, _property.PropertyType);
-                    if (c != null)
-                    {
-                        Converter = c;
-                        return;
-                    }
-                }
-
-                throw new AvroException($"Property {property.Name} in object {property.DeclaringType} isn't compatible with Avro schema type {schemaTag}");
+                throw new AvroException($"Property {property.Name} in object {property.DeclaringType} isn't compatible with Avro schema type {schema.Tag}");
             }
         }
 
-        public DotnetProperty(PropertyInfo property, Avro.Schema.Type schemaTag, ClassCache cache)
-            : this(property, schemaTag, null, cache)
+        public DotnetProperty(PropertyInfo property, Avro.Schema schema, ClassCache cache)
+            : this(property, schema, null, cache)
         {
         }
 

--- a/lang/csharp/src/apache/main/Reflect/NullableConverter.cs
+++ b/lang/csharp/src/apache/main/Reflect/NullableConverter.cs
@@ -29,6 +29,9 @@ namespace Avro.Reflect
     {
         private readonly IAvroFieldConverter _converter;
 
+        /// <summary>
+        /// Creates a new instance of <see cref="NullableConverter{T}"/> for the <see cref="T"/>
+        /// </summary>
         public NullableConverter()
         {
             var converter = new T();
@@ -38,21 +41,39 @@ namespace Avro.Reflect
                 converter.GetPropertyType().MakeNullable());
         }
 
+        /// <summary>
+        /// Converts the possibly-null property instance to a null or the converted type for Avro
+        /// </summary>
+        /// <param name="o">The property value</param>
+        /// <param name="s">The schema</param>
+        /// <returns>Null or the converted instance</returns>
         public object ToAvroType(object o, Schema s)
         {
             return this._converter.ToAvroType(o, s);
         }
 
+        /// <summary>
+        /// Converts the possibly-null Avro field to null or an instance of the property
+        /// </summary>
+        /// <param name="o">The Avro value</param>
+        /// <param name="s">The schema</param>
+        /// <returns></returns>
         public object FromAvroType(object o, Schema s)
         {
             return this._converter.FromAvroType(o, s);
         }
 
+        /// <summary>
+        /// Returns the Avro type as a nullable type
+        /// </summary>
         public Type GetAvroType()
         {
             return this._converter.GetAvroType();
         }
 
+        /// <summary>
+        /// Returns the Property type as a nullable type
+        /// </summary>
         public Type GetPropertyType()
         {
             return this._converter.GetPropertyType();

--- a/lang/csharp/src/apache/main/Reflect/NullableConverter.cs
+++ b/lang/csharp/src/apache/main/Reflect/NullableConverter.cs
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+
+namespace Avro.Reflect
+{
+    /// <summary>
+    /// A helper to create a NullableConverter over a non-nullable one
+    /// </summary>
+    /// <typeparam name="T">Any <see cref="IAvroFieldConverter"/></typeparam>
+    public class NullableConverter<T> : IAvroFieldConverter
+        where T : class, IAvroFieldConverter, new()
+    {
+        private readonly IAvroFieldConverter _converter;
+
+        public NullableConverter()
+        {
+            var converter = new T();
+            this._converter = new NullableConverter(
+                converter,
+                converter.GetAvroType().MakeNullable(),
+                converter.GetPropertyType().MakeNullable());
+        }
+
+        public object ToAvroType(object o, Schema s)
+        {
+            return this._converter.ToAvroType(o, s);
+        }
+
+        public object FromAvroType(object o, Schema s)
+        {
+            return this._converter.FromAvroType(o, s);
+        }
+
+        public Type GetAvroType()
+        {
+            return this._converter.GetAvroType();
+        }
+
+        public Type GetPropertyType()
+        {
+            return this._converter.GetPropertyType();
+        }
+    }
+
+    /// <summary>
+    /// A class that wraps a converter to support nullable conversions
+    /// </summary>
+    internal class NullableConverter : IAvroFieldConverter
+    {
+        private readonly IAvroFieldConverter _converter;
+        private readonly Type _avroType;
+        private readonly Type _propType;
+
+        public NullableConverter(IAvroFieldConverter converter, Type avroType, Type propType)
+        {
+            this._converter = converter;
+            this._avroType = avroType;
+            this._propType = propType;
+        }
+
+        public object ToAvroType(object o, Schema s)
+        {
+            if (o == null)
+            {
+                return null;
+            }
+
+            return this._converter.ToAvroType(o, s);
+        }
+
+        public object FromAvroType(object o, Schema s)
+        {
+            if (o == null)
+            {
+                return null;
+            }
+
+            return this._converter.FromAvroType(o, s);
+        }
+
+        public Type GetAvroType()
+        {
+            return this._avroType;
+        }
+
+        public Type GetPropertyType()
+        {
+            return this._propType;
+        }
+    }
+}

--- a/lang/csharp/src/apache/main/Reflect/NullableConverter.cs
+++ b/lang/csharp/src/apache/main/Reflect/NullableConverter.cs
@@ -21,66 +21,6 @@ using System;
 namespace Avro.Reflect
 {
     /// <summary>
-    /// A helper to create a NullableConverter over a non-nullable one
-    /// </summary>
-    /// <typeparam name="T">Any <see cref="IAvroFieldConverter"/></typeparam>
-    public class NullableConverter<T> : IAvroFieldConverter
-        where T : class, IAvroFieldConverter, new()
-    {
-        private readonly IAvroFieldConverter _converter;
-
-        /// <summary>
-        /// Creates a new instance of <see cref="NullableConverter{T}"/> for the <see typeparam="T"/>
-        /// </summary>
-        public NullableConverter()
-        {
-            var converter = new T();
-            this._converter = new NullableConverter(
-                converter,
-                converter.GetAvroType().MakeNullable(),
-                converter.GetPropertyType().MakeNullable());
-        }
-
-        /// <summary>
-        /// Converts the possibly-null property instance to a null or the converted type for Avro
-        /// </summary>
-        /// <param name="o">The property value</param>
-        /// <param name="s">The schema</param>
-        /// <returns>Null or the converted instance</returns>
-        public object ToAvroType(object o, Schema s)
-        {
-            return this._converter.ToAvroType(o, s);
-        }
-
-        /// <summary>
-        /// Converts the possibly-null Avro field to null or an instance of the property
-        /// </summary>
-        /// <param name="o">The Avro value</param>
-        /// <param name="s">The schema</param>
-        /// <returns></returns>
-        public object FromAvroType(object o, Schema s)
-        {
-            return this._converter.FromAvroType(o, s);
-        }
-
-        /// <summary>
-        /// Returns the Avro type as a nullable type
-        /// </summary>
-        public Type GetAvroType()
-        {
-            return this._converter.GetAvroType();
-        }
-
-        /// <summary>
-        /// Returns the Property type as a nullable type
-        /// </summary>
-        public Type GetPropertyType()
-        {
-            return this._converter.GetPropertyType();
-        }
-    }
-
-    /// <summary>
     /// A class that wraps a converter to support nullable conversions
     /// </summary>
     internal class NullableConverter : IAvroFieldConverter
@@ -88,6 +28,16 @@ namespace Avro.Reflect
         private readonly IAvroFieldConverter _converter;
         private readonly Type _avroType;
         private readonly Type _propType;
+
+        public static IAvroFieldConverter CreateNullableWrapper(IAvroFieldConverter converter, Type propType)
+        {
+            if (propType.IsNullable() && !converter.GetPropertyType().IsNullable())
+            {
+                return new NullableConverter(converter, converter.GetAvroType(), propType.MakeNullable());
+            }
+
+            return converter;
+        }
 
         public NullableConverter(IAvroFieldConverter converter, Type avroType, Type propType)
         {

--- a/lang/csharp/src/apache/main/Reflect/NullableConverter.cs
+++ b/lang/csharp/src/apache/main/Reflect/NullableConverter.cs
@@ -30,7 +30,7 @@ namespace Avro.Reflect
         private readonly IAvroFieldConverter _converter;
 
         /// <summary>
-        /// Creates a new instance of <see cref="NullableConverter{T}"/> for the <see cref="T"/>
+        /// Creates a new instance of <see cref="NullableConverter{T}"/> for the <see typeparam="T"/>
         /// </summary>
         public NullableConverter()
         {

--- a/lang/csharp/src/apache/main/Reflect/README.md
+++ b/lang/csharp/src/apache/main/Reflect/README.md
@@ -106,6 +106,40 @@ _Example TypedFieldConverter_:
     }
 ```
 
+### Nullable primitive properties
+
+Converters for primitive types (int, long, decimal, etc) automatically work with simple nullable unions/properties with the converters defined for the 
+non-nullable type.  You can create one converter and it will work for both nullable and non-nullable properties.
+
+```csharp
+        public class StringToDecimalConverter : TypedFieldConverter<string,decimal>
+        {
+            public override decimal From(string o, Schema s)
+            {
+                return decimal.Parse(o);
+            }
+
+            public override string To(decimal o, Schema s)
+            {
+                return o.Value;
+            }
+        }
+
+        public class MyModel1
+        {
+            [AvroField(typeof(DateTimeOffsetToLongConverter))]
+            public decimal Amount { get; set; }
+        }
+
+        public class MyModel2
+        {
+            [AvroField(typeof(DateTimeOffsetToLongConverter))]
+            public decimal? Amount { get; set; }
+        }
+```
+
+
+
 ### Default Converters
 
 Default converters are defined to convert between an Avro primitive and C# type without explicitly defining the converter for a field. Default converters are static and are registered with the class cache.
@@ -116,6 +150,7 @@ Default converters are defined to convert between an Avro primitive and C# type 
     var reader = new ReflectReader<GenericFixedRec>(schema, schema);
 
 ```
+
 ## Attributes
 
 The AvroField attribute can be used to defined field converters or to change the name of the dotnet property (or both).

--- a/lang/csharp/src/apache/main/Reflect/TypedFieldConverter.cs
+++ b/lang/csharp/src/apache/main/Reflect/TypedFieldConverter.cs
@@ -51,7 +51,7 @@ namespace Avro.Reflect
         /// <returns></returns>
         public object FromAvroType(object o, Schema s)
         {
-            if (!typeof(TAvro).IsAssignableFrom(o.GetType()))
+            if (o != null && !typeof(TAvro).IsAssignableFrom(o.GetType()))
             {
                 throw new AvroException($"Converter from {typeof(TAvro).Name} to {typeof(TProperty).Name} cannot convert object of type {o.GetType().Name} to {typeof(TAvro).Name}, object {o.ToString()}");
             }
@@ -85,7 +85,7 @@ namespace Avro.Reflect
         /// <returns></returns>
         public object ToAvroType(object o, Schema s)
         {
-            if (!typeof(TProperty).IsAssignableFrom(o.GetType()))
+            if (o != null && !typeof(TProperty).IsAssignableFrom(o.GetType()))
             {
                 throw new AvroException($"Converter from {typeof(TAvro).Name} to {typeof(TProperty).Name} cannot convert object of type {o.GetType().Name} to {typeof(TProperty).Name}, object {o.ToString()}");
             }

--- a/lang/csharp/src/apache/main/TypeConversionHelper.cs
+++ b/lang/csharp/src/apache/main/TypeConversionHelper.cs
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+
+namespace Avro
+{
+    internal static class TypeConversionHelper
+    {
+        /// <summary>
+        /// Returns true iof the type is a <see cref="Nullable"/> of a primitive type
+        /// </summary>
+        public static bool IsNullable(this Type type)
+        {
+            return type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>);
+        }
+
+        /// <summary>
+        /// Returns the primitive or Nullable&lt;T&gt; type as a <see cref="Nullable"/> or null if it cannot be expressed as a Nullable&lt;T&gt;
+        /// </summary>
+        public static Type MakeNullable(this Type type)
+        {
+            return type.IsPrimitive
+                ? typeof(Nullable<>).MakeGenericType(type)
+                : IsNullable(type)
+                    ? type
+                    : null;
+        }
+
+        /// <summary>
+        /// Returns the Nullable or primitive type as a primitive type or null if it cannot be expressed as primitive.
+        /// </summary>
+        public static Type MakePrimitive(this Type type)
+        {
+            return type.IsPrimitive
+                ? type
+                : IsNullable(type)
+                    ? type.GetGenericArguments()[0]
+                    : null;
+        }
+    }
+}

--- a/lang/csharp/src/apache/test/Avro.test.csproj
+++ b/lang/csharp/src/apache/test/Avro.test.csproj
@@ -21,6 +21,8 @@
     <TargetFrameworks Condition="'$(OS)'=='Windows_NT'">net461;netcoreapp3.1</TargetFrameworks>
     <RootNamespace>Avro.test</RootNamespace>
     <AssemblyName>Avro.test</AssemblyName>
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>..\..\..\Avro.snk</AssemblyOriginatorKeyFile>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GenerateProgramFile>false</GenerateProgramFile>
   </PropertyGroup>


### PR DESCRIPTION
See also: https://github.com/apache/avro/pull/1088

### Jira

- [x] My PR addresses the following [Avro Jira](https://issues.apache.org/jira/browse/AVRO/AVRO-3041) issues and references them in the PR title.
  - https://issues.apache.org/jira/browse/AVRO-3041

### Tests

- [x] My PR adds the following unit tests
- SerializeNullableWithNullableConverter
- SerializeNullableDefaultWithClass
- SerializeNullableDefaultWithDelegate
- SerializeNullableDefaultWithNullableDelegate
- SerializeNullableDefaultWithDoubleNullableDelegate

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.

